### PR TITLE
添加 AI Router 到 CN Platform

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,7 @@ You may also want to read my other posts:
 - [CN Platform](#cn-platform)
   - [ModelScope（魔搭社区）](#modelscope魔搭社区仅限cnonly-cn)
   - [SilliconFlow 硅基流动](#silliconflow-硅基流动)
+  - [AI Router](#ai-router)
   - [Tencent-Hunyuan 腾讯混元](#tencent-hunyuan-腾讯混元)
   - [Volcengine 火山引擎（平台）](#volcengine-火山引擎平台-500-point-资源点day)
   - [心流](#心流)
@@ -742,6 +743,17 @@ https://modelscope.cn/docs/model-service/API-Inference/limits </br>
 ### SilliconFlow 硅基流动
 **部分**小模型免费；新cn手机用户注册送**20M token** </br>
 https://siliconflow.cn/
+
+-------
+
+### AI Router
+https://ai-router.dev/cn </br>
+API Endpoint: https://api.ai-router.dev/v1 </br>
+
+- OpenAI 兼容 API 中转服务，通过 API Key 使用。
+- 新用户注册后直接解锁 5U；另外最多 15U 在符合条件的充值后按 1:1 解锁。
+- 每日签到奖励为 1 USD + 昨日消费额的 2%，以站内活动规则和实际到账为准。
+- 非 OpenAI 官方服务；当前模型可用性请以 `/v1/models` 和站内说明为准。
 
 -------
 

--- a/readme.md
+++ b/readme.md
@@ -750,10 +750,10 @@ https://siliconflow.cn/
 https://ai-router.dev/cn </br>
 API Endpoint: https://api.ai-router.dev/v1 </br>
 
-- OpenAI 兼容 API 中转服务，通过 API Key 使用。
-- 新用户注册后直接解锁 5U；另外最多 15U 在符合条件的充值后按 1:1 解锁。
-- 每日签到奖励为 1 USD + 昨日消费额的 2%，以站内活动规则和实际到账为准。
-- 非 OpenAI 官方服务；当前模型可用性请以 `/v1/models` 和站内说明为准。
+- 独立运营的 OpenAI 兼容 API 中转服务，通过个人 API Key 使用。
+- 可在现有兼容客户端或脚本中配置 Base URL，并在控制台查看用量。
+- 当前模型及可用性请以 `/v1/models` 和站内说明为准。
+- 非 OpenAI 官方服务；新用户权益以站内当前规则为准，不作为永久免费 API 承诺。
 
 -------
 
@@ -829,6 +829,5 @@ Spark-lite free </br>
 - 首次开通后，免费包（个人）有200k免费额度（所有模型),有效期为一年</br>
 https://www.xfyun.cn/doc/spark/HTTP调用文档.html   
 https://xinghuo.xfyun.cn/sparkapi?scr=price
-
 
 


### PR DESCRIPTION
## 提交说明

将 AI Router 添加到 CN Platform，并补充目录导航。

条目只包含可核验信息：
- 中文页面：`https://ai-router.dev/cn`
- OpenAI 兼容 API Endpoint：`https://api.ai-router.dev/v1`
- 新用户注册后直接解锁 5U；最多额外 15U 在符合条件的充值后按 1:1 解锁
- 每日签到奖励为 1 USD + 昨日消费额的 2%，以站内活动规则和实际到账为准
- 非 OpenAI 官方服务；不列出未核验的模型、价格或节点承诺

这是 AI Router 运营方的自提交，无返利链接。